### PR TITLE
only log fatal messages

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,6 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   config.logger = Logger.new(nil)
+  config.log_level = :FATAL
   # Configure static file server for tests with Cache-Control for performance.
   config.serve_static_files   = true
   config.static_cache_control = 'public, max-age=3600'


### PR DESCRIPTION
We have a bunch of logger stuff that is like `return unless logger.debug?`.  The logger is in debug mode, so we should set it to `FATAL` so that debugging code doesn't run.
